### PR TITLE
fix:AttributeError: 'method' object has no attribute 'interaction' under python3

### DIFF
--- a/ropemacs/__init__.py
+++ b/ropemacs/__init__.py
@@ -336,9 +336,14 @@ the rope-marker-ring")
         if hasattr(callback, 'im_func'):
             callback = callback.im_func
         if prefix:
-            callback.interaction = 'P'
+            callback_interaction = 'P'
         else:
-            callback.interaction = ''
+            callback_interaction = ''
+
+        try:
+            callback.interaction = callback_interaction
+        except AttributeError:
+            callback.__func__.interaction = callback_interaction
 
     def add_hook(self, name, callback, hook):
         mapping = {'before_save': 'before-save-hook',


### PR DESCRIPTION
(1)when run (pymacs-load "ropemacs" "rope-") under python3,got errors:
AttributeError: 'method' object has no attribute 'interaction'
(2)found a fix at stackoverflow
https://stackoverflow.com/questions/7034063/adding-attributes-to-instancemethods-in-python
------------------------
For attribute lookup, Python is automatically using the real function attached to the instance method for you.

For attribute setting, it is not.

They are two separate operations depending on which side of the statement you're on, even though they both use the . operator.

When you access an instance method's __func__, you're manually accessing the real function that actually has the moo attribute.

In Python 3 this will work as you would like / expect as methods are basically just functions.