### PR TITLE
handle case when lisp.file_remote_p returns `None`

### DIFF
--- a/ropemacs/__init__.py
+++ b/ropemacs/__init__.py
@@ -150,7 +150,9 @@ class LispUtils(ropemode.environment.Environment):
             lisp.set_buffer(initial)
 
     def path_on_lisp_host(self, path_on_python_host):
-        return lisp.file_remote_p(lisp['default-directory'].value()) + path_on_python_host
+        default_directory = lisp['default-directory'].value()
+        path = lisp.file_remote_p(default_directory)
+        return (path or default_directory) + path_on_python_host
 
     def find_file(self, filename, readonly=False, other=False):
         filename = self.path_on_lisp_host(filename)

--- a/ropemacs/__init__.py
+++ b/ropemacs/__init__.py
@@ -1,5 +1,6 @@
 """ropemacs, an emacs mode for using rope refactoring library"""
 import sys
+from os.path import join
 
 import ropemode.decorators
 import ropemode.environment
@@ -152,7 +153,7 @@ class LispUtils(ropemode.environment.Environment):
     def path_on_lisp_host(self, path_on_python_host):
         default_directory = lisp['default-directory'].value()
         path = lisp.file_remote_p(default_directory)
-        return (path or default_directory) + path_on_python_host
+        return join((path or default_directory) , path_on_python_host)
 
     def find_file(self, filename, readonly=False, other=False):
         filename = self.path_on_lisp_host(filename)


### PR DESCRIPTION
file-remote-p can be `nil`

```
file-remote-p is a compiled Lisp function in ‘files.el’.

(file-remote-p FILE &optional IDENTIFICATION CONNECTED)

  Probably introduced at or before Emacs version 22.1.

Test whether FILE specifies a location on a remote system.
A file is considered remote if accessing it is likely to
be slower or less reliable than accessing local files.

‘file-remote-p’ never opens a new remote connection.  It can
reuse only a connection that is already open.

Return nil or a string identifying the remote connection
(ideally a prefix of FILE).  Return nil if FILE is a relative
file name.

When IDENTIFICATION is nil, the returned string is a complete
remote identifier: with components method, user, and host.  The
components are those present in FILE, with defaults filled in for
any that are missing.

IDENTIFICATION can specify which part of the identification to
return.  IDENTIFICATION can be the symbol ‘method’, ‘user’,
‘host’, or ‘localname’.  Any other value is handled like nil and
means to return the complete identification.  The string returned
for IDENTIFICATION ‘localname’ can differ depending on whether
there is an existing connection.

If CONNECTED is non-nil, return an identification only if FILE is
located on a remote system and a connection is established to
that remote system.

Tip: You can use this expansion of remote identifier components
     to derive a new remote file name from an existing one.  For
     example, if FILE is "/sudo::/path/to/file" then

       (concat (file-remote-p FILE) "/bin/sh")

     returns a remote file name for file "/bin/sh" that has the
     same remote identifier as FILE but expanded; a name such as
```